### PR TITLE
PP-789: add scroll view to avoid inputs getting covered by keyboard

### DIFF
--- a/src/views/settings/components/backups/BackupPasswordPrompt.tsx
+++ b/src/views/settings/components/backups/BackupPasswordPrompt.tsx
@@ -120,7 +120,7 @@ export default (): ReactElement => {
           isValid={passwordIsValid && passwordMatch}
         />
         <Input
-          style={tw`mt-2 h-12`}
+          style={tw`mt-2`}
           testID="backup-passwordRepeat"
           reference={(el: any) => ($passwordRepeat = el)}
           onChange={onPasswordRepeatChange}


### PR DESCRIPTION
adjustPan on the android manifest leads to many layout issues because the keyboard would just overlay content of the app, without the app being aware of the keyboard.

I therefore decided the best way forward is to apply a scrollview on the screen so android can scroll to the input field and avoid it being covered by the keyboard.

Because I cannot reproduce this error, this is a blind fix. I know you probably can’t either. So if you think it’s a good approach, let’s have Lab and steph test it out on testnet later.