### PR TITLE
PP-893: ensure that dependencies are kept

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -19,3 +19,4 @@
 
 # Package: bdk-rn
 -keep class com.sun.jna.** { *; }
+-keep class org.bitcoindevkit.** { *; }


### PR DESCRIPTION
 found and 2 issues after compiling my android APK. They did not occur while running react-native via react-native run-android

```
"code": "Init Wallet Error"
"message": "Can't obtain peer field ID for class com.sun.jna.Pointer"
```
&

```
"code": "Init Wallet Error"
"message": ""
```

----

The fix for these issues is simply adding the following proguard rules in my project:

```
# Package: bdk-rn
-keep class com.sun.jna.** { *; }
-keep class org.bitcoindevkit.** { *; }
```