### PR TITLE
PP-919: prevent splash screen being stuck by waiting for user permiss…

### DIFF
--- a/src/init/initApp.ts
+++ b/src/init/initApp.ts
@@ -23,5 +23,5 @@ export const initApp = async (): Promise<void> => {
     await dataMigrationAfterLoadingAccount()
   }
 
-  await requestUserPermissions()
+  requestUserPermissions()
 }


### PR DESCRIPTION
…ions

My hunch was correct, the splash screen prevents the user permissions dialogue to pop up. The watchdog then terminates the app after 20 seconds.
Fix is to call `requestUserPermissions` asynchronously