### PR TITLE
PP-919: request user permissions after splash screen hides

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ import { error, info } from './utils/log'
 import { getRequiredActionCount } from './utils/offer'
 import { marketPrices } from './utils/peachAPI/public/market'
 import { compatibilityCheck, linkToAppStore } from './utils/system'
+import requestUserPermissions from './init/requestUserPermissions'
 
 enableScreens()
 
@@ -184,6 +185,7 @@ const App: React.FC = () => {
       await initApp()
       setCurrentPage(!!account?.publicKey ? 'home' : 'welcome')
       await initialNavigation(navigationRef, updateMessage)
+      requestUserPermissions()
 
       updateAppContext({
         notifications: getChatNotifications() + getRequiredActionCount(),

--- a/src/init/initApp.ts
+++ b/src/init/initApp.ts
@@ -1,6 +1,5 @@
 import { dataMigrationAfterLoadingAccount, dataMigrationBeforeLoadingAccount } from '../init/dataMigration'
 import events from '../init/events'
-import requestUserPermissions from '../init/requestUserPermissions'
 import userUpdate from '../init/userUpdate'
 import { account, loadAccount } from '../utils/account'
 import { getPeachInfo } from './getPeachInfo'
@@ -16,12 +15,10 @@ export const initApp = async (): Promise<void> => {
 
   await loadAccount()
   await getPeachInfo(account)
-  await saveMeetupEvents()
   if (account?.publicKey) {
     getTrades()
     userUpdate()
     await dataMigrationAfterLoadingAccount()
   }
-
-  requestUserPermissions()
+  saveMeetupEvents()
 }


### PR DESCRIPTION
Picking up where we left off, I decided to move the notification permission popup until after the splash screen hides as it seems it can't show while the splash screen is still active.