### PR TITLE
feature/PP-1248-add-nonce-value-to-cash

### DIFF
--- a/src/@types/paymentdata.d.ts
+++ b/src/@types/paymentdata.d.ts
@@ -50,5 +50,5 @@ declare type AmazonGiftCardData = {
   email: string
 }
 declare type CashData = {
-  nonce: string
+  userId: string
 }

--- a/src/components/payment/hooks/useMeetupScreenSetup.tsx
+++ b/src/components/payment/hooks/useMeetupScreenSetup.tsx
@@ -35,7 +35,7 @@ export const useMeetupScreenSetup = () => {
     const meetup: PaymentData = {
       id: 'cash.' + meetupInfo.id,
       label: event.shortName,
-      nonce: account.publicKey,
+      userId: account.publicKey,
       type: meetupInfo.id,
       currencies: meetupInfo.currencies,
       country: event.country,


### PR DESCRIPTION
Hi @MManke188 instead of a random nonce, it occurred to me that the public key of a user a better random value as it will be always the same. This way, the payment data hash is closely tied to the user's account.

I named the field `userId` then because we technically can have the counterparty verify validity of the payment data.