### PR TITLE
bugfix/PP-1181-cannot-enter-custom-amount

### DIFF
--- a/src/components/inputs/verticalAmountSelector/SelectAmount.tsx
+++ b/src/components/inputs/verticalAmountSelector/SelectAmount.tsx
@@ -84,7 +84,8 @@ export const SelectAmount = ({ min, max, value, onChange, style }: RangeAmountPr
             <ToolTip style={tw`absolute right-8 w-[175px]`}>
               <View style={tw`absolute top-0 left-0 right-0 z-10`}>
                 <Input
-                  style={[tw`w-full h-10`, { opacity: 0.01 }]}
+                  style={[tw`w-full h-20 p-0 text-xl`, { opacity: 0.01 }]}
+                  inputStyle={tw`h-20 p-0 text-3xl`}
                   keyboardType="number-pad"
                   value={value.toString()}
                   onChange={updateCustomAmount}


### PR DESCRIPTION
Trying to hack the TextInput to show a styled component instead. My hypothesis is that Graphene OS does not allow focus on invisible input fields. Therefore I give it an opacity of 0.01 to hopefully make it work. 
 I also increased the hittable area of the hidden input field to ensure that it's easy to focus