### PR TITLE
bugfix/PP-1313-collaborative-cancel-trade

### DIFF
--- a/src/overlays/dispute/hooks/useDisputeRaisedNotice.tsx
+++ b/src/overlays/dispute/hooks/useDisputeRaisedNotice.tsx
@@ -108,6 +108,7 @@ export const useDisputeRaisedNotice = () => {
             icon: 'arrowRightCircle',
             callback: () => {
               submit(contract, contract.disputeReason ?? 'other')
+              navigation.replace('contract', { contractId: contract.id })
             },
           }
           : {

--- a/src/overlays/dispute/hooks/useDisputeResults.tsx
+++ b/src/overlays/dispute/hooks/useDisputeResults.tsx
@@ -87,6 +87,7 @@ export const useDisputeResults = () => {
           callback: () => {
             saveAcknowledgeMent()
             closeOverlay()
+            navigation.replace('contract', { contractId: contract.id })
           },
         },
         action1: {

--- a/src/overlays/tradeCancelation/useBuyerRejectedCancelTradeOverlay.tsx
+++ b/src/overlays/tradeCancelation/useBuyerRejectedCancelTradeOverlay.tsx
@@ -1,22 +1,25 @@
 import React, { useCallback, useContext } from 'react'
 import { OverlayContext } from '../../contexts/overlay'
+import { useNavigation } from '../../hooks'
 import { saveContract } from '../../utils/contract'
 import i18n from '../../utils/i18n'
 import { BuyerRejectedCancelTrade } from './BuyerRejectedCancelTrade'
 
 export const useBuyerRejectedCancelTradeOverlay = () => {
   const [, updateOverlay] = useContext(OverlayContext)
+  const navigation = useNavigation()
 
   const confirmOverlay = useCallback(
     (contract: Contract) => {
       updateOverlay({ visible: false })
+      navigation.replace('contract', { contractId: contract.id })
       saveContract({
         ...contract,
         cancelConfirmationDismissed: true,
         cancelConfirmationPending: false,
       })
     },
-    [updateOverlay],
+    [updateOverlay, navigation],
   )
 
   const showCancelTradeRequestRejected = useCallback(


### PR DESCRIPTION
I first tried to implement a zustand store that could be shared across multiple scopes, however that concept is not yet riped out and would require more refactoring and testing.
Therefore I opted for a quick-win which I wouldn't leave forever but it fixes the issue at hand. The quick-win is to replace the current screen so the stored contract is loaded anew into the state.