### PR TITLE
Exclude src/views/TestView directory from coverage

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -24,5 +24,6 @@
     "\\.(ttf|woff|woff2|eot|otf)$": "jest-transform-stub",
     "\\.(jpg|jpeg|png|gif|webp|svg|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
     "^@env(.*)$": "<rootDir>/.env.dist$1"
-  }
+  },
+  "coveragePathIgnorePatterns": ["/node_modules/", "src/views/TestView"]
 }


### PR DESCRIPTION
Note that this PR is just a suggestion, I'd also be fine with not excluding the test view.
I wanted to get rid of some of the <50% covered directories, and there were multiple ones from src/views/TestView, hence this proposal