### PR TITLE
fix: Fix reason for dispute display

### DIFF
--- a/src/views/dispute/DisputeReasonSelector.tsx
+++ b/src/views/dispute/DisputeReasonSelector.tsx
@@ -29,8 +29,8 @@ export const DisputeReasonSelector = () => {
 };
 
 const disputeReasons: Record<ContractViewer, DisputeReason[]> = {
-  buyer: ["noPayment.buyer", "unresponsive.buyer", "abusive", "other"],
-  seller: ["noPayment.seller", "unresponsive.seller", "abusive", "other"],
+  buyer: ["noPayment.seller", "unresponsive.seller", "abusive", "other"],
+  seller: ["noPayment.buyer", "unresponsive.buyer", "abusive", "other"],
 };
 
 function DisputeReasonScreen({ contract }: { contract: Contract }) {


### PR DESCRIPTION
Fix for issue [PP-3145](https://peachbitcoin.atlassian.net/jira/software/projects/PP/issues/PP-3145)

The intended behaviour was for buyers to see and select reasons related to sellers and vice versa. This fix does just that.

[PP-3145]: https://peachbitcoin.atlassian.net/browse/PP-3145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ