### PR TITLE
fix UAH missing from currency tabs and wrong Asia default currency

### DIFF
--- a/src/views/addPaymentMethod/constants.ts
+++ b/src/views/addPaymentMethod/constants.ts
@@ -5,7 +5,7 @@ export const defaultCurrencies: Record<CurrencyType, Currency> = {
   latinAmerica: "ARS",
   africa: "ZAR",
   global: "USDT",
-  asia: "AED",
+  asia: "INR",
   northAmerica: "CAD",
   middleEast: "ILS",
   oceania: "AUD",

--- a/src/views/addPaymentMethod/getCurrencyTypeFilter.ts
+++ b/src/views/addPaymentMethod/getCurrencyTypeFilter.ts
@@ -18,6 +18,7 @@ const CURRENCY_MAP: Record<CurrencyType, Currency[]> = {
     "ISK",
     "RON",
     "TRY",
+    "UAH",
   ],
   latinAmerica: [
     "DOC",


### PR DESCRIPTION
- Add UAH to europe tab in getCurrencyTypeFilter (was causing crashes when selecting Ukrainian hryvnia)
- Fix asia default currency from AED (Middle East) to INR which is actually in the asia tab

This is an attempt to fix this https://t.me/c/1855272059/4736:
> And i discovered a currencies (MYR, UAH) that when is tapped cause app crash       

I don't know if it will work but they are both bugs that need to be fixed anyhow. 